### PR TITLE
refactor: Phase 2 - Medium priority fixes

### DIFF
--- a/src/datasets/transform.py
+++ b/src/datasets/transform.py
@@ -1,5 +1,16 @@
-# src/datasets/transform.py
+"""Data augmentation transforms for semantic segmentation.
+
+This module provides various transformation classes for augmenting image and label pairs
+during training. All transforms operate on dictionaries with 'im' (image) and 'lb' (label) keys.
+
+Transforms include:
+- Geometric: RandomScale, RandomHorizontalFlip, RandomCrop, RandomRotate
+- Photometric: RandomColorJitter, RandomGamma, RandomNoise, RandomGrayscale
+- Regularization: RandomCutout, RandomGaussianBlur
+"""
+
 import random
+from typing import Dict, Tuple, Optional
 
 from PIL import Image, ImageEnhance
 import numpy as np

--- a/src/models/cabinet.py
+++ b/src/models/cabinet.py
@@ -217,8 +217,15 @@ class CABiNet(nn.Module):
         self.conv_out = CABiNetOutput(256, 256, n_classes)
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass through CABiNet model.
+
+        Args:
+            x: Input tensor of shape (N, 3, H, W)
+
+        Returns:
+            Tuple of (final_logit, high_res_logit_up) each of shape (N, num_classes, H, W)
+        """
         H, W = x.shape[2:]
-        # device = x.device
 
         # Extract features
         feat_sb = self.sb(x)  # (B, 128, H/8, W/8)


### PR DESCRIPTION
This commit addresses medium-priority refactoring issues:

1. Remove commented-out dead code:
   - Removed unused `# device = x.device` in cabinet.py
   - Cleaned up code comments that served no purpose

2. Fix inconsistent naming conventions:
   - Renamed `h_sigmoid` → `HardSigmoid` (PascalCase)
   - Renamed `h_swish` → `HardSwish` (PascalCase)
   - Updated all references throughout mobilenetv3.py
   - Added type annotations to activation classes
   - Added docstrings explaining each activation function

3. Add comprehensive docstrings:
   - Added module-level docstring to transform.py
   - Added detailed docstring to CABiNet forward() method
   - Added docstrings to HardSigmoid and HardSwish classes
   - Improved documentation across the codebase

4. Improve code documentation:
   - Added typing imports where needed
   - Enhanced existing docstrings with better descriptions
   - Added parameter and return type documentation

Files changed:
- Modified: src/models/cabinet.py (remove dead code, add docstrings)
- Modified: src/models/mobilenetv3.py (rename classes, add types)
- Modified: src/datasets/transform.py (add module docstring, imports)

Impact:
- Improved code readability and maintainability
- Better IDE support with proper class names
- Enhanced documentation for developers
- Consistent naming conventions throughout